### PR TITLE
feat: Add enum for rule metrics

### DIFF
--- a/src/galileo_protect/__init__.py
+++ b/src/galileo_protect/__init__.py
@@ -2,6 +2,18 @@
 # ruff: noqa: F401
 from galileo_protect.invoke import invoke
 from galileo_protect.project import create_project
+from galileo_protect.schemas import (
+    OverrideAction,
+    PassthroughAction,
+    Payload,
+    Request,
+    Response,
+    Rule,
+    RuleMetrics,
+    RuleOperator,
+    Ruleset,
+    Stage,
+)
 from galileo_protect.stage import create_stage
 
 __version__ = "0.2.0"

--- a/src/galileo_protect/schemas/__init__.py
+++ b/src/galileo_protect/schemas/__init__.py
@@ -18,3 +18,4 @@ from galileo_core.schemas.protect.ruleset import Ruleset
 from galileo_core.schemas.protect.stage import Stage
 
 from galileo_protect.schemas.invoke import Response
+from galileo_protect.schemas.rule import RuleMetrics

--- a/src/galileo_protect/schemas/rule.py
+++ b/src/galileo_protect/schemas/rule.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class RuleMetrics(str, Enum):
+    input_pii = "input_pii"
+    input_sexist = "input_sexist"
+    input_tone = "input_tone"
+    input_toxicity = "input_toxicity"
+    pii = "pii"
+    sexist = "sexist"
+    tone = "tone"
+    toxicity = "toxicity"


### PR DESCRIPTION
Adding an enum (and pulling it up to a top-level export) so that it can be referenced when creating rules.