### PR TITLE
feat(stage): Add methods to pause, resume stage

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -337,13 +337,13 @@ testing = ["hatch", "pre-commit", "pytest", "tox"]
 
 [[package]]
 name = "filelock"
-version = "3.13.3"
+version = "3.13.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.13.3-py3-none-any.whl", hash = "sha256:5ffa845303983e7a0b7ae17636509bc97997d58afeafa72fb141a17b152284cb"},
-    {file = "filelock-3.13.3.tar.gz", hash = "sha256:a79895a25bbefdf55d1a2a0a80968f7dbb28edcd6d4234a0afb3f37ecde4b546"},
+    {file = "filelock-3.13.4-py3-none-any.whl", hash = "sha256:404e5e9253aa60ad457cae1be07c0f0ca90a63931200a47d9b6a6af84fd7b45f"},
+    {file = "filelock-3.13.4.tar.gz", hash = "sha256:d13f466618bfde72bd2c18255e269f72542c6e70e7bac83a0232d6b1cc5c8cf4"},
 ]
 
 [package.extras]
@@ -370,13 +370,13 @@ sphinx-basic-ng = "*"
 
 [[package]]
 name = "galileo-core"
-version = "0.10.0"
+version = "0.11.0"
 description = "Shared schemas and configuration for Galileo's Python packages."
 optional = false
 python-versions = "<3.13,>=3.8.1"
 files = [
-    {file = "galileo_core-0.10.0-py3-none-any.whl", hash = "sha256:5927dcaf5e7314e78f810a0cf0c8b5ce321eb08bb8023cfe2cc602e36b349c65"},
-    {file = "galileo_core-0.10.0.tar.gz", hash = "sha256:b65854a027e65cf11b4c698e0c1f5cbb6fdd714ef6adffc0e510af14b64b96c9"},
+    {file = "galileo_core-0.11.0-py3-none-any.whl", hash = "sha256:8ec9a16059ea2bf1078ae9e6d60f03e8e028f0982dd89a86d32905cf0bef048a"},
+    {file = "galileo_core-0.11.0.tar.gz", hash = "sha256:5c01c184ecaa54b1b45108dffed45a59d5c9fcec427c422e1aafefeee5d16b37"},
 ]
 
 [package.dependencies]
@@ -1504,4 +1504,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1,<3.13"
-content-hash = "4aee9458438b4b8dc7da14ffa6df838a238b969b4cfb35ad4f2f351f94dc6bd4"
+content-hash = "a2d0fc7a63a907a78a82c0445c27a76c972d873d8102d7b91913f55e48028b3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "galileo_protect", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.8.1,<3.13"
-galileo-core = "^0.10.0"
+galileo-core = "^0.11.0"
 
 
 [tool.poetry.group.test.dependencies]

--- a/src/galileo_protect/__init__.py
+++ b/src/galileo_protect/__init__.py
@@ -14,6 +14,6 @@ from galileo_protect.schemas import (
     Ruleset,
     Stage,
 )
-from galileo_protect.stage import create_stage
+from galileo_protect.stage import create_stage, pause_stage, resume_stage
 
 __version__ = "0.3.0"

--- a/src/galileo_protect/constants/routes.py
+++ b/src/galileo_protect/constants/routes.py
@@ -2,4 +2,6 @@ from types import SimpleNamespace
 
 # We cannot use Enum here because `mypy` doesn't like it when we format those routes
 # into strings. https://github.com/python/mypy/issues/15269
-Routes = SimpleNamespace(invoke="protect/invoke", stages="projects/{project_id}/stages")
+Routes = SimpleNamespace(
+    invoke="protect/invoke", stages="projects/{project_id}/stages", stage="projects/{project_id}/stages/{stage_id}"
+)

--- a/src/galileo_protect/stage.py
+++ b/src/galileo_protect/stage.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 from galileo_core.utils.name import ts_name
 from pydantic import UUID4
-from requests import post
+from requests import post, put
 
 from galileo_protect.constants.routes import Routes
 from galileo_protect.helpers.config import ProtectConfig
@@ -37,3 +37,69 @@ def create_stage(
     config.stage_name = stage.name
     config.write()
     return stage
+
+
+def pause_stage(
+    project_id: Optional[UUID4] = None, stage_id: Optional[UUID4] = None, config: Optional[ProtectConfig] = None
+) -> None:
+    """
+    Pause a stage.
+
+    If the stage is already paused, the rulesets in the stage will not be evaluated.
+
+    Parameters
+    ----------
+    project_id : Optional[UUID4], optional
+        Project ID, by default None and will be taken from the config.
+    stage_id : Optional[UUID4], optional
+        Stage ID, by default None and will be taken from the config.
+    config : Optional[ProtectConfig], optional
+        Protect config, by default None and will be taken from the env vars or the local
+        config file.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError
+        If the project ID is not provided or found.
+    ValueError
+        If the stage ID is not provided or found.
+    """
+    config = config or ProtectConfig.get()
+    project_id = project_id or config.project_id
+    stage_id = stage_id or config.stage_id
+    if project_id is None:
+        raise ValueError("Project ID must be provided to pause a stage.")
+    if stage_id is None:
+        raise ValueError("Stage ID must be provided to pause a stage.")
+    config.api_client.request(
+        put,
+        Routes.stage.format(project_id=project_id, stage_id=stage_id),
+        params=dict(action_enabled=True),
+    )
+    config.project_id = project_id
+    config.stage_id = stage_id
+    config.write()
+
+
+def resume_stage(
+    project_id: Optional[UUID4] = None, stage_id: Optional[UUID4] = None, config: Optional[ProtectConfig] = None
+) -> None:
+    config = config or ProtectConfig.get()
+    project_id = project_id or config.project_id
+    stage_id = stage_id or config.stage_id
+    if project_id is None:
+        raise ValueError("Project ID must be provided to resume a stage.")
+    if stage_id is None:
+        raise ValueError("Stage ID must be provided to resume a stage.")
+    config.api_client.request(
+        put,
+        Routes.stage.format(project_id=project_id, stage_id=stage_id),
+        params=dict(action_enabled=False),
+    )
+    config.project_id = project_id
+    config.stage_id = stage_id
+    config.write()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,21 +1,22 @@
-from typing import Callable, Optional
+from typing import Callable, Union
+from urllib.parse import urlencode
 from uuid import uuid4
 
 from pytest import mark, raises
-from requests_mock import POST
+from requests_mock import POST, PUT
 
 from galileo_protect.constants.routes import Routes
-from galileo_protect.schemas import Action, PassthroughAction
+from galileo_protect.schemas import Action, OverrideAction, PassthroughAction
 from galileo_protect.schemas.stage import StageResponse
-from galileo_protect.stage import create_stage
+from galileo_protect.stage import create_stage, pause_stage, resume_stage
 
 
 class TestCreate:
     @mark.parametrize(
         ["name", "description", "action", "action_enabled"],
         [
-            ("stage", "description", None, False),
-            ("stage", "description", None, False),
+            ("stage", "description", OverrideAction(choices=["foo"]), False),
+            ("stage", "description", OverrideAction(choices=["foo"]), True),
             ("stage", "description", PassthroughAction(), False),
             ("stage", "description", PassthroughAction(), True),
         ],
@@ -26,7 +27,7 @@ class TestCreate:
         mock_request: Callable,
         name: str,
         description: str,
-        action: Optional[Action],
+        action: Action,
         action_enabled: bool,
     ) -> None:
         config = set_validated_config()
@@ -62,8 +63,8 @@ class TestCreate:
     @mark.parametrize(
         ["name", "description", "action", "action_enabled"],
         [
-            ("stage", "description", None, False),
-            ("stage", "description", None, False),
+            ("stage", "description", OverrideAction(choices=["foo"]), False),
+            ("stage", "description", OverrideAction(choices=["foo"]), True),
             ("stage", "description", PassthroughAction(), False),
             ("stage", "description", PassthroughAction(), True),
         ],
@@ -74,7 +75,7 @@ class TestCreate:
         mock_request: Callable,
         name: str,
         description: str,
-        action: Optional[Action],
+        action: Action,
         action_enabled: bool,
     ) -> None:
         project_id, stage_id = uuid4(), uuid4()
@@ -109,8 +110,8 @@ class TestCreate:
     @mark.parametrize(
         ["name", "description", "action", "action_enabled"],
         [
-            ("stage", "description", None, False),
-            ("stage", "description", None, False),
+            ("stage", "description", OverrideAction(choices=["foo"]), False),
+            ("stage", "description", OverrideAction(choices=["foo"]), True),
             ("stage", "description", PassthroughAction(), False),
             ("stage", "description", PassthroughAction(), True),
         ],
@@ -120,10 +121,106 @@ class TestCreate:
         set_validated_config: Callable,
         name: str,
         description: str,
-        action: Optional[Action],
+        action: Action,
         action_enabled: bool,
     ) -> None:
         config = set_validated_config()
         with raises(ValueError) as exc_info:
             create_stage(config=config)
         assert str(exc_info.value) == "Project ID must be provided to create a stage."
+
+
+class TestPause:
+    @mark.parametrize("action_enabled", ["true", True])
+    def test_params(
+        self, set_validated_config: Callable, mock_request: Callable, action_enabled: Union[str, bool]
+    ) -> None:
+        project_id, stage_id = uuid4(), uuid4()
+        config = set_validated_config()
+        matcher = mock_request(
+            PUT,
+            Routes.stage.format(project_id=project_id, stage_id=stage_id)
+            + "?"
+            + urlencode({"action_enabled": action_enabled}),
+        )
+        pause_stage(project_id=project_id, stage_id=stage_id, config=config)
+        assert matcher.called
+        assert config.project_id == project_id
+        assert config.stage_id == stage_id
+
+    @mark.parametrize("action_enabled", ["true", True])
+    def test_project_id_from_config(
+        self, set_validated_config: Callable, mock_request: Callable, action_enabled: Union[str, bool]
+    ) -> None:
+        project_id, stage_id = uuid4(), uuid4()
+        config = set_validated_config(project_id=project_id, stage_id=stage_id)
+        matcher = mock_request(
+            PUT,
+            Routes.stage.format(project_id=project_id, stage_id=stage_id)
+            + "?"
+            + urlencode({"action_enabled": action_enabled}),
+        )
+        pause_stage(config=config)
+        assert matcher.called
+        assert config.project_id == project_id
+        assert config.stage_id == stage_id
+
+    def test_raises_missing_project_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config()
+        with raises(ValueError) as exc_info:
+            pause_stage(config=config)
+        assert str(exc_info.value) == "Project ID must be provided to pause a stage."
+
+    def test_raises_missing_stage_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config()
+        with raises(ValueError) as exc_info:
+            pause_stage(project_id=uuid4(), config=config)
+        assert str(exc_info.value) == "Stage ID must be provided to pause a stage."
+
+
+class TestResume:
+    @mark.parametrize("action_enabled", ["false", False])
+    def test_params(
+        self, set_validated_config: Callable, mock_request: Callable, action_enabled: Union[str, bool]
+    ) -> None:
+        project_id, stage_id = uuid4(), uuid4()
+        config = set_validated_config()
+        matcher = mock_request(
+            PUT,
+            Routes.stage.format(project_id=project_id, stage_id=stage_id)
+            + "?"
+            + urlencode({"action_enabled": action_enabled}),
+        )
+        resume_stage(project_id=project_id, stage_id=stage_id, config=config)
+        assert matcher.called
+        assert config.project_id == project_id
+        assert config.stage_id == stage_id
+
+    @mark.parametrize("action_enabled", ["false", False])
+    def test_project_id_from_config(
+        self, set_validated_config: Callable, mock_request: Callable, action_enabled: Union[str, bool]
+    ) -> None:
+        project_id, stage_id = uuid4(), uuid4()
+        config = set_validated_config(project_id=project_id, stage_id=stage_id)
+        matcher = mock_request(
+            PUT,
+            Routes.stage.format(project_id=project_id, stage_id=stage_id)
+            + "?"
+            + urlencode({"action_enabled": action_enabled}),
+        )
+        resume_stage(config=config)
+        assert matcher.called
+        assert config.project_id == project_id
+        assert config.stage_id == stage_id
+
+    def test_raises_missing_project_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config()
+        with raises(ValueError) as exc_info:
+            pause_stage(config=config)
+        assert str(exc_info.value) == "Project ID must be provided to pause a stage."
+
+    def test_raises_missing_stage_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config()
+        with raises(ValueError) as exc_info:
+            pause_stage(project_id=uuid4(), config=config)
+        assert str(exc_info.value) == "Stage ID must be provided to pause a stage."


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/galileo/story/15300/api-hook-up-stage-action-to-supersede-all-other-actions

Adding Python client support to interact with the addition from https://github.com/rungalileo/api/pull/2042.

Tests:
- [x] Local.
- [x] CI.