### PR TITLE
feat(rule-metrics): Include prompt injection in enum

### DIFF
--- a/src/galileo_protect/schemas/rule.py
+++ b/src/galileo_protect/schemas/rule.py
@@ -6,6 +6,7 @@ class RuleMetrics(str, Enum):
     input_sexist = "input_sexist"
     input_tone = "input_tone"
     input_toxicity = "input_toxicity"
+    prompt_injection = "prompt_injection"
     pii = "pii"
     sexist = "sexist"
     tone = "tone"


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/galileo/story/15408/add-prompt-injection-support

Just verified that this metric works, so enabling it.