### PR TITLE
feat(langchain): Add flags for ignoring trigger, echoing output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = [{include = "galileo_protect", from = "src"}]
 [tool.poetry.dependencies]
 python = "^3.8.1,<3.13"
 galileo-core = "^0.15.0"
+
 langchain-core = { version = "^0.1.52", optional = true }
 
 

--- a/tests/test_langchain.py
+++ b/tests/test_langchain.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.llms import LLM
-from pytest import mark
+from pytest import CaptureFixture, mark
 
 from galileo_protect.langchain import ProtectParser
 
@@ -25,17 +25,29 @@ class ProtectLLM(LLM):
 
 
 @mark.parametrize(
-    ["output", "expected_return", "expected_call_count"],
+    ["output", "ignore_trigger", "expected_return", "expected_call_count"],
     [
-        [dumps({"text": "foo"}), "foo", 1],
-        [dumps({"text": "timeout", "status": "TIMEOUT"}), "timeout", 1],
-        [dumps({"text": "success", "status": "SUCCESS"}), "success", 1],
-        [dumps({"text": "triggered", "status": "TRIGGERED"}), "triggered", 0],
+        [dumps({"text": "foo"}), False, "foo", 1],
+        [dumps({"text": "foo"}), True, "foo", 1],
+        [dumps({"text": "timeout", "status": "TIMEOUT"}), False, "timeout", 1],
+        [dumps({"text": "timeout", "status": "TIMEOUT"}), True, "timeout", 1],
+        [dumps({"text": "success", "status": "SUCCESS"}), False, "success", 1],
+        [dumps({"text": "success", "status": "SUCCESS"}), True, "success", 1],
+        [dumps({"text": "triggered", "status": "TRIGGERED"}), False, "triggered", 0],
+        [dumps({"text": "triggered", "status": "TRIGGERED"}), True, "triggered", 1],
     ],
 )
-def test_parser(output: str, expected_return: str, expected_call_count: int) -> None:
-    parser = ProtectParser(chain=ProtectLLM())
+def test_parser(output: str, ignore_trigger: bool, expected_return: str, expected_call_count: int) -> None:
+    parser = ProtectParser(chain=ProtectLLM(), ignore_trigger=ignore_trigger)
     with patch.object(ProtectLLM, "invoke", wraps=parser.chain.invoke) as mock_fn:
         return_value = parser.parser(output)
         assert return_value == expected_return
         assert mock_fn.call_count == expected_call_count
+
+
+@mark.parametrize(["echo_output", "expected_output"], [[True, "> Raw response: foo\n"], [False, ""]])
+def test_echo(echo_output: bool, expected_output: str, capsys: CaptureFixture) -> None:
+    parser = ProtectParser(chain=ProtectLLM(), echo_output=echo_output)
+    parser.parser(dumps({"text": "foo"}))
+    captured = capsys.readouterr()
+    assert captured.out == expected_output


### PR DESCRIPTION
Tiny update to #30 that allows us to display the model's output to `stdout` if requested and ignore the protect response.

Tests:
- [x] Local.
- [x] CI.