### PR TITLE
feat(stages): Add ability to update stage with new rulesets

### DIFF
--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,4 +1,4 @@
-from typing import Callable, Sequence, Union
+from typing import Callable, List, Union
 from uuid import uuid4
 
 from galileo_core.constants.request_method import RequestMethod
@@ -10,7 +10,13 @@ from pytest import mark, raises
 
 from galileo_protect.constants.routes import Routes
 from galileo_protect.schemas.stage import StageResponse
-from galileo_protect.stage import create_stage, get_stage, pause_stage, resume_stage
+from galileo_protect.stage import (
+    create_stage,
+    get_stage,
+    pause_stage,
+    resume_stage,
+    update_stage,
+)
 from tests.data import A_PROJECT_NAME, A_STAGE_NAME
 
 
@@ -109,7 +115,7 @@ class TestCreate:
         mock_request: Callable,
         description: str,
         pause: bool,
-        rulesets: Sequence[Ruleset],
+        rulesets: List[Ruleset],
     ) -> None:
         config = set_validated_config()
         project_id, stage_id = uuid4(), uuid4()
@@ -162,7 +168,7 @@ class TestCreate:
         mock_request: Callable,
         description: str,
         pause: bool,
-        rulesets: Sequence[Ruleset],
+        rulesets: List[Ruleset],
     ) -> None:
         project_id, stage_id = uuid4(), uuid4()
         config = set_validated_config(project_id=project_id)
@@ -321,6 +327,42 @@ class TestGet:
         config = set_validated_config(project_id=uuid4())
         with raises(ValueError) as exc_info:
             get_stage(config=config)
+        assert str(exc_info.value) == "Stage ID or name must be provided to get a stage."
+
+
+class TestUpdate:
+    def test_simple(self, rulesets: List[Ruleset], set_validated_config: Callable, mock_request: Callable) -> None:
+        project_id, stage_id = uuid4(), uuid4()
+        config = set_validated_config()
+        response = StageResponse(
+            id=stage_id, name=A_STAGE_NAME, project_id=project_id, version=1, type=StageType.central
+        )
+        matcher = mock_request(
+            RequestMethod.POST,
+            Routes.stage.format(project_id=project_id, stage_id=stage_id),
+            json=response.model_dump(mode="json"),
+        )
+        stage = update_stage(project_id=project_id, stage_id=stage_id, prioritzed_rulesets=rulesets, config=config)
+        assert matcher.called
+        assert config.project_id == project_id
+        assert config.stage_id == stage_id
+        assert config.stage_name == A_STAGE_NAME
+        assert config.stage_version == 1
+        assert stage.id == stage_id
+        assert stage.version == 1
+        assert stage.name == A_STAGE_NAME
+        assert stage.type == StageType.central
+
+    def test_raises_missing_project_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config()
+        with raises(ValueError) as exc_info:
+            update_stage(config=config)
+        assert str(exc_info.value) == "Project ID or name must be provided to get a stage."
+
+    def test_raises_missing_stage_id(self, set_validated_config: Callable) -> None:
+        config = set_validated_config(project_id=uuid4())
+        with raises(ValueError) as exc_info:
+            update_stage(config=config)
         assert str(exc_info.value) == "Stage ID or name must be provided to get a stage."
 
 


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/galileo/story/17516/gp-add-helper-to-update-stage-with-new-rulesets

Description: And the ability to update a stage. Corollary to https://github.com/rungalileo/api/pull/2244.

Tests:
- [x] Local.
- [x] CI.