### PR TITLE
chore(docs): Remove `griffe-typingdoc` mkdocs extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,5 +58,4 @@ plugins:
             merge_init_into_class: true
             separate_signature: true
             extensions:
-              - griffe_typingdoc
               - griffe_fieldz: { include_inherited: true }

--- a/poetry.lock
+++ b/poetry.lock
@@ -429,21 +429,6 @@ dev = ["black", "ipython", "mypy", "pdbpp", "pre-commit", "rich", "ruff"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
-name = "griffe-typingdoc"
-version = "0.2.5"
-description = "Griffe extension for PEP 727 – Documentation Metadata in Typing."
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "griffe_typingdoc-0.2.5-py3-none-any.whl", hash = "sha256:9de51529c46cc318b5920f999518f220a2b267d38568b7a62839020282aa2072"},
-    {file = "griffe_typingdoc-0.2.5.tar.gz", hash = "sha256:88d308ebd9ccbb6d7270356900b987fcc6b7854e7d461a970916397427b0f9a6"},
-]
-
-[package.dependencies]
-griffe = ">=0.38"
-typing-extensions = ">=4.7"
-
-[[package]]
 name = "h11"
 version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
@@ -1777,4 +1762,4 @@ langchain = ["langchain-core"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1,<3.13"
-content-hash = "459faf9c74971f88cc7badaf9cff002f09e0e56134ab1b1841d9f7e57db6aaf2"
+content-hash = "be595eaf6f02bdc5e7b785e459c29222ae748e16267de69e7a60ed1a8e17eeac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ mkdocstrings = "^0.25.1"
 mkdocstrings-python = "^1.10.2"
 mkdocs-material = "^9.5.24"
 griffe-fieldz = "^0.1.2"
-griffe-typingdoc = "^0.2.5"
 
 
 [build-system]


### PR DESCRIPTION
This is producing duplicate [params](https://protect.docs.rungalileo.io/#galileo_protect.update_stage) in the docs right now.