### PR TITLE
fix: Allow setting project name from `ProtectTool`, use `project_name` from config if available

### DIFF
--- a/src/galileo_protect/invocation.py
+++ b/src/galileo_protect/invocation.py
@@ -66,7 +66,7 @@ async def ainvoke(
             payload=payload,
             rulesets=prioritized_rulesets or [],
             project_id=project_id or config.project_id,
-            project_name=project_name,
+            project_name=project_name or config.project_name,
             stage_name=stage_name or config.stage_name,
             stage_id=stage_id or config.stage_id,
             timeout=timeout,

--- a/src/galileo_protect/langchain.py
+++ b/src/galileo_protect/langchain.py
@@ -30,6 +30,7 @@ class ProtectTool(BaseTool):
 
     prioritized_rulesets: Optional[Sequence[Ruleset]] = None
     project_id: Optional[UUID4] = None
+    project_name: Optional[str] = None
     stage_name: Optional[str] = None
     stage_id: Optional[UUID4] = None
     timeout: float = TIMEOUT
@@ -45,6 +46,7 @@ class ProtectTool(BaseTool):
         return invoke(
             payload=payload,
             prioritized_rulesets=self.prioritized_rulesets,
+            project_name=self.project_name,
             project_id=self.project_id,
             stage_name=self.stage_name,
             stage_id=self.stage_id,


### PR DESCRIPTION
Forgot both of these tiny changes in #140.