### PR TITLE
ci(docs): Drop `project-name` arg from docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -53,4 +53,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy --project-name=protect-docs
+          command: pages deploy


### PR DESCRIPTION
We get this from `wrangler.toml`.