### PR TITLE
ci: Use fully defined GH action for pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,10 +1,16 @@
-name: Style Check
+name: pre-commit
 
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [$default-branch]
 
 jobs:
   pre-commit:
-    uses: rungalileo/.github/.github/workflows/pre-commit.yaml@main
+    runs-on: ubuntu-latest
+    env:
+      SKIP: "mypy"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Can't use shared workflows in public repos.